### PR TITLE
Fix CI: update pnpm setup + portable compile-proto

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,18 +23,18 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-        - uses: actions/checkout@v2
-        - uses: pnpm/action-setup@v2.2.2
+        - uses: actions/checkout@v4
+        - uses: pnpm/action-setup@v4
           with:
-            version: 7
+            version: 10
         - name: Use Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v2
+          uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node-version }}
-            cache: 'pnpm'
+            cache: pnpm
 
         - name: Install dependencies & build
           run: pnpm install && pnpm run build && pnpm run compile-proto

--- a/compile-proto.sh
+++ b/compile-proto.sh
@@ -2,8 +2,10 @@ npx pbjs --sparse --es6 -t static-module -w es6 -o src/misc/push-request.js -p p
 
 cd src/misc
 
-# what the fuck
-sed -i 's|import \* as $protobuf|import $protobuf|' push-request.js
-sed -i 's|protobufjs/minimal|protobufjs/minimal.js|' push-request.js
+# Portable in-place edits (GNU sed vs BSD sed)
+sed -i.bak 's|import \* as $protobuf|import $protobuf|' push-request.js
+sed -i.bak 's|protobufjs/minimal|protobufjs/minimal.js|' push-request.js
+rm -f push-request.js.bak
+
 npx pbts -o push-request.d.mts push-request.js
 mv -f push-request.js push-request.mjs

--- a/src/misc/push-request.d.mts
+++ b/src/misc/push-request.d.mts
@@ -1,4 +1,5 @@
 import * as $protobuf from "protobufjs";
+import Long = require("long");
 /** Namespace PushRequestPackage. */
 export namespace PushRequestPackage {
 

--- a/src/misc/push-request.mjs
+++ b/src/misc/push-request.mjs
@@ -103,12 +103,14 @@ export const PushRequestPackage = $root.PushRequestPackage = (() => {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        PushRequest.decode = function decode(reader, length) {
+        PushRequest.decode = function decode(reader, length, error) {
             if (!(reader instanceof $Reader))
                 reader = $Reader.create(reader);
             let end = length === undefined ? reader.len : reader.pos + length, message = new $root.PushRequestPackage.PushRequest();
             while (reader.pos < end) {
                 let tag = reader.uint32();
+                if (tag === error)
+                    break;
                 switch (tag >>> 3) {
                 case 1: {
                         if (!(message.streams && message.streams.length))
@@ -349,12 +351,14 @@ export const PushRequestPackage = $root.PushRequestPackage = (() => {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        StreamAdapter.decode = function decode(reader, length) {
+        StreamAdapter.decode = function decode(reader, length, error) {
             if (!(reader instanceof $Reader))
                 reader = $Reader.create(reader);
             let end = length === undefined ? reader.len : reader.pos + length, message = new $root.PushRequestPackage.StreamAdapter();
             while (reader.pos < end) {
                 let tag = reader.uint32();
+                if (tag === error)
+                    break;
                 switch (tag >>> 3) {
                 case 1: {
                         message.labels = reader.string();
@@ -622,12 +626,14 @@ export const PushRequestPackage = $root.PushRequestPackage = (() => {
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        EntryAdapter.decode = function decode(reader, length) {
+        EntryAdapter.decode = function decode(reader, length, error) {
             if (!(reader instanceof $Reader))
                 reader = $Reader.create(reader);
             let end = length === undefined ? reader.len : reader.pos + length, message = new $root.PushRequestPackage.EntryAdapter();
             while (reader.pos < end) {
                 let tag = reader.uint32();
+                if (tag === error)
+                    break;
                 switch (tag >>> 3) {
                 case 1: {
                         message.timestamp = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
@@ -875,12 +881,14 @@ export const google = $root.google = (() => {
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Timestamp.decode = function decode(reader, length) {
+            Timestamp.decode = function decode(reader, length, error) {
                 if (!(reader instanceof $Reader))
                     reader = $Reader.create(reader);
                 let end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
                 while (reader.pos < end) {
                     let tag = reader.uint32();
+                    if (tag === error)
+                        break;
                     switch (tag >>> 3) {
                     case 1: {
                             message.seconds = reader.int64();


### PR DESCRIPTION
Fixes failing GitHub Actions runs:

- Update pnpm/action-setup and actions/* to current versions
- Update Node test matrix to maintained versions (18/20/22)
- Make compile-proto.sh portable across GNU/BSD sed
- Regenerate generated protobuf outputs

This resolves pnpm/action-setup failure (ERR_INVALID_THIS / URLSearchParams).